### PR TITLE
chore(dev-env): migrate from direnv to mise

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-use node
-layout node

--- a/mise-tasks/postinstall.mjs
+++ b/mise-tasks/postinstall.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  try {
+    // Get PNPM version using mise
+    const pnpmVersion = execSync('mise -C "${HOME}" x pnpm -- pnpm -v')
+      .toString()
+      .trim();
+
+    // Read and update package.json
+    const packagePath = path.join(__dirname, "..", "package.json");
+    const packageJson = JSON.parse(execSync(`cat ${packagePath}`).toString());
+
+    packageJson.packageManager = `pnpm@${pnpmVersion}`;
+
+    // Write updated package.json
+    await writeFile(
+      packagePath,
+      JSON.stringify(packageJson, undefined, 2) + "\n",
+    );
+
+    console.log("Updated packageManager in package.json");
+  } catch (error) {
+    console.error("Error updating package.json:", error);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[env]
+_.path = ["node_modules/.bin"]
+
+[tools]
+node = "lts"
+pnpm = "latest"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "indianagy-dot-com",
   "type": "module",
   "version": "1.0.0",
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.5.0",
   "pnpm": {
     "overrides": {
       "tailwindcss": "<4"
@@ -13,7 +13,7 @@
     "build": "astro build",
     "deploy": "netlify build && netlify deploy --prod",
     "dev": "astro dev",
-    "postinstall": "if command -v jq &> /dev/null; then pnpm_version=$(pnpm --version) && jq --arg version \"$pnpm_version\" '.packageManager = \"pnpm@\" + $version' package.json > tmp.json && mv tmp.json package.json; else echo 'jq not found, skipping packageManager update'; fi",
+    "postinstall": "is-ci || mise postinstall",
     "preview": "netlify serve"
   },
   "dependencies": {
@@ -42,6 +42,7 @@
     "@types/node": "^22.13.1",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "is-ci": "^4.1.0",
     "netlify-cli": "^18.0.4",
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
+      is-ci:
+        specifier: ^4.1.0
+        version: 4.1.0
       netlify-cli:
         specifier: ^18.0.4
         version: 18.0.4(@types/node@22.13.1)(picomatch@4.0.2)(rollup@4.34.1)
@@ -3254,6 +3257,10 @@ packages:
   is-builtin-module@3.2.1:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
+
+  is-ci@4.1.0:
+    resolution: {integrity: sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==}
+    hasBin: true
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -9440,6 +9447,10 @@ snapshots:
   is-builtin-module@3.2.1:
     dependencies:
       builtin-modules: 3.3.0
+
+  is-ci@4.1.0:
+    dependencies:
+      ci-info: 4.1.0
 
   is-core-module@2.16.1:
     dependencies:


### PR DESCRIPTION
- Replace `.envrc` with `mise.toml` for environment management
- Add postinstall script to dynamically update `packageManager` in `package.json`
- Introduce `is-ci` to conditionally run postinstall script
- Update PNPM version to latest (10.5.0)
- Simplify development environment configuration
