### PR TITLE
feat: add GA4 event tracking for resume downloads

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -31,7 +31,17 @@ const currentYear = new Date().getFullYear();
       target="_blank"
       class="flex w-fit items-center gap-2"
       rel="noopener noreferrer"
-      onclick="return fetch(this.href).then(r => r.ok ? true : alert('Resume temporarily unavailable'))"
+      onclick="
+        if (typeof gtag !== 'undefined') {
+          gtag('event', 'file_download', {
+            file_name: 'resume.pdf',
+            file_extension: 'pdf',
+            link_url: this.href,
+            link_text: 'Download my resume'
+          });
+        }
+        return fetch(this.href).then(r => r.ok ? true : alert('Resume temporarily unavailable'));
+      "
     >
       <FileText size="18" aria-hidden="true" />
       Download my resume


### PR DESCRIPTION
## Summary
- Added Google Analytics 4 event tracking to the resume download link in the footer
- Tracks user interactions with the resume download button using the standard `file_download` event
- Maintains all existing error handling functionality

## Implementation Details
The tracking implementation sends the following data to GA4:
- **Event name**: `file_download` (standard GA4 event)
- **File name**: resume.pdf
- **File extension**: pdf
- **Link URL**: The R2 download URL
- **Link text**: "Download my resume"

## Where to View Data
Once deployed, resume download events will be visible in GA4:
- Events → `file_download` for detailed event data  
- Engagement → Downloads (enhanced measurement report)
- Reports → Engagement → Events for custom analysis

## Testing
- The implementation checks for `gtag` availability before sending events
- Works with both testing and production GA4 properties based on environment variables
- Preserves the existing fetch validation and error alert functionality

## Test Plan
- [ ] Verify the site builds successfully
- [ ] Test clicking the resume download link
- [ ] Confirm events appear in GA4 dashboard
- [ ] Verify error handling still works when resume is unavailable