### PR TITLE
feat: upgrade to Ubuntu Noble 24.04 build image and Node.js 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,14 @@
+[build]
+  command = "pnpm run build"
+  publish = "dist"
+  environment = { NODE_VERSION = "22" }
+
+[build.environment]
+  NETLIFY_IMAGE = "focal"
+
+[context.production]
+  environment = { NETLIFY_IMAGE = "noble" }
+
 [dev]
 host = "0.0.0.0"
 port = 4321


### PR DESCRIPTION
## Summary
- Upgrades Netlify build environment from Focal to Ubuntu Noble 24.04
- Updates Node.js version from 20 to 22 (current LTS)
- Addresses upcoming end of Focal support on January 1, 2026

## Changes
- Updated `netlify.toml` to specify Noble build image for production
- Upgraded Node.js version to 22 to match local development environment
- Maintained backward compatibility for other build contexts

## Test plan
- [ ] Verify successful build on Netlify with Noble image
- [ ] Confirm Node.js 22 is properly configured
- [ ] Test site functionality remains unchanged

Closes #107