### PR TITLE
feat: add Netlify cache plugin for Astro build cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,13 @@
+[build]
+  command = "pnpm run build"
+  publish = "dist"
+  environment = { NODE_VERSION = "22" }
+
+[[plugins]]
+  package = "netlify-plugin-cache"
+  [plugins.inputs]
+    paths = ["node_modules/.astro"]
+
 [dev]
 host = "0.0.0.0"
 port = 4321

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "astro": "^5.13.7",
     "is-ci": "^4.1.0",
     "netlify-cli": "^23.5.1",
+    "netlify-plugin-cache": "^1.0.3",
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       netlify-cli:
         specifier: ^23.5.1
         version: 23.5.1(@types/node@24.3.3)(picomatch@4.0.3)(rollup@4.50.1)
+      netlify-plugin-cache:
+        specifier: ^1.0.3
+        version: 1.0.3
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
@@ -3860,6 +3863,9 @@ packages:
     resolution: {integrity: sha512-CeWygxSDEoBMvVz4osfBI0euADqX7rDL0MTM9HW/TZPS54IrubmnfhSdhFRaONB4JtfRuNLzAV0wra5xYSWNTg==}
     engines: {node: '>=20.12.2'}
     hasBin: true
+
+  netlify-plugin-cache@1.0.3:
+    resolution: {integrity: sha512-CTOwNWrTOP59T6y6unxQNnp1WX702v2R/faR5peSH94ebrYfyY4zT5IsRcIiHKq57jXeyCrhy0GLuTN8ktzuQg==}
 
   netlify-redirector@0.5.0:
     resolution: {integrity: sha512-4zdzIP+6muqPCuE8avnrgDJ6KW/2+UpHTRcTbMXCIRxiRmyrX+IZ4WSJGZdHPWF3WmQpXpy603XxecZ9iygN7w==}
@@ -10001,6 +10007,8 @@ snapshots:
       - supports-color
       - uploadthing
       - utf-8-validate
+
+  netlify-plugin-cache@1.0.3: {}
 
   netlify-redirector@0.5.0: {}
 


### PR DESCRIPTION
## Summary
- Install netlify-plugin-cache to cache `node_modules/.astro` directory
- Configure netlify.toml with plugin to improve build performance between deployments
- Validated configuration with `netlify build --dry` command

## Test plan
- [x] Validate netlify.toml configuration with netlify CLI
- [ ] Deploy to Netlify and verify cache plugin works
- [ ] Monitor build times for improved performance